### PR TITLE
Fix summary and move transforms to deployment.yml

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,72 +1,52 @@
 [sqlfluff]
-
 dialect = redshift
-
 templater = dbt
-
 exclude_rules = ambiguous.column_count, structure.column_order
-
 max_line_length = 120
-
-# CPU processes to use while linting.
-# The default is "single threaded" to allow easy debugging, but this
-# is often undesirable at scale.
-# If positive, just implies number of processes.
-# If negative or zero, implies number_of_cpus - specified_number.
-# e.g. -1 means use all processors but one. 0 means all cpus.
 processes = -1
 
-# If using the dbt templater, we recommend setting the project dir.
 [sqlfluff:templater:dbt]
 project_dir = ./
 
+[sqlfluff:templater:jinja]
+apply_dbt_builtins = True
+load_macros_from_path = ./macros
+
 [sqlfluff:indentation]
-# While implicit indents are not enabled by default. Many of the
-# SQLFluff maintainers do use them in their projects.
 allow_implicit_indents = FALSE
-indented_joins = True
+indented_joins = TRUE
+indented_ctes = TRUE
 
 [sqlfluff:layout:type:comma]
 line_position = leading
 
-# The default configuration for aliasing rules is "consistent"
-# which will auto-detect the setting from the rest of the file. This
-# is less desirable in a new project and you may find this (slightly
-# more strict) setting more useful.
+[sqlfluff:layout:type:alias_expression]
+spacing_before = align
+align_within = select_clause
+align_scope = bracketed
+
+[sqlfluff:layout:type:common_table_expression]
+spacing_within = single
+
 [sqlfluff:rules:aliasing.table]
 aliasing = explicit
+
 [sqlfluff:rules:aliasing.column]
 aliasing = explicit
 
-# The default configuration for capitalisation rules is "consistent"
-# which will auto-detect the setting from the rest of the file. This
-# is less desirable in a new project and you may find this (slightly
-# more strict) setting more useful.
-# Typically we find users rely on syntax highlighting rather than
-# capitalisation to distinguish between keywords and identifiers.
-# Clearly, if your organisation has already settled on uppercase
-# formatting for any of these syntax elements then set them to "upper".
-# See https://stackoverflow.com/questions/608196/why-should-i-capitalize-my-sql-keywords-is-there-a-good-reason
 [sqlfluff:rules:capitalisation.keywords]
 capitalisation_policy = upper
+
 [sqlfluff:rules:capitalisation.identifiers]
 capitalisation_policy = lower
+
 [sqlfluff:rules:capitalisation.functions]
 extended_capitalisation_policy = upper
+
 [sqlfluff:rules:capitalisation.literals]
 capitalisation_policy = upper
+
 [sqlfluff:rules:capitalisation.types]
 extended_capitalisation_policy = upper
 
-[sqlfluff:layout:type:alias_expression]
-# We want non-default spacing _before_ the alias expressions.
-spacing_before = align
-# We want to align them within the next outer select clause.
-# This means for example that alias expressions within the FROM
-# or JOIN clause would _not_ be aligned with them.
-align_within = select_clause
-# The point at which to stop searching outward for siblings, which
-# in this example would likely be the boundary of a CTE. Stopping
-# when we hit brackets is usually a good rule of thumb for this
-# configuration.
-align_scope = bracketed
+

--- a/deployment.yml
+++ b/deployment.yml
@@ -11,3 +11,35 @@ jobs:
    steps:
      - name: run daysheet summary # Give each step in your job a name. This will enable you to track the steps in the logs.
        command: dbt run --models +mrt_daysheet_summary # Enter the dbt command that should run in this step. This example will run all your models. For a list of available commands visit https://docs.getdbt.com/reference/model-selection-syntax/.
+       
+ - name: utility_runner
+   targetName: dev 
+   schedule: '30 8 * * 1-5' 
+   timeout: 15m
+   steps:
+     - name: run utility tables 
+       command: dbt run --models +util_runner
+
+ - name: daysheet_daily_refresh
+   targetName: dev 
+   schedule: '30 7 * * 1-5' 
+   timeout: 60m
+   steps:
+     - name: run full refresh on daysheet tables 
+       command: dbt run --full-refresh --models mrt_daysheet_debits mrt_daysheet_credits mrt_daysheet_adjustments mrt_daysheet_cashpayments
+
+ - name: table_sizes
+   targetName: dev 
+   schedule: '30 * * * *' 
+   timeout: 40m
+   steps:
+     - name: table_sizes 
+       command: dbt run --models +table_sizes
+
+ - name: node_storage
+   targetName: dev 
+   schedule: '5 * * * *' 
+   timeout: 10m
+   steps:
+     - name: node_storage 
+       command: dbt run --models +node_storage

--- a/models/marts/daysheet/mrt_daysheet_adjustments.sql
+++ b/models/marts/daysheet/mrt_daysheet_adjustments.sql
@@ -21,6 +21,7 @@ WITH fresh_data AS (
         lit_created_at,
         lit_posted_date,
         era_deposit_date,
+        date_of_service, 
         lit_adjustment,
         li_updated_at,
         appt_updated_at,

--- a/models/marts/daysheet/mrt_daysheet_credits.sql
+++ b/models/marts/daysheet/mrt_daysheet_credits.sql
@@ -21,6 +21,7 @@ WITH fresh_data AS (
         lit_created_at,
         lit_posted_date,
         era_deposit_date,
+        date_of_service, 
         ins_paid,
         li_updated_at,
         appt_updated_at,

--- a/models/marts/daysheet/mrt_daysheet_summary.sql
+++ b/models/marts/daysheet/mrt_daysheet_summary.sql
@@ -2,6 +2,7 @@
     config(
         SORT=["practice_group_id", "doctor_id"],
         materialized = "view",
+        bind=False
     ) 
 }}
 

--- a/models/staging/stg_patients.sql
+++ b/models/staging/stg_patients.sql
@@ -10,7 +10,7 @@ SELECT
     , middle_name AS patient_middle_name
     , last_name   AS patient_last_name
     , CASE
-        WHEN middle_name = ''
+        WHEN middle_name IS NULL
             THEN first_name || ' ' || last_name
         WHEN middle_name IS NOT NULL
             THEN first_name || ' ' || middle_name || ' ' || last_name

--- a/models/util/util_runner.sql
+++ b/models/util/util_runner.sql
@@ -1,5 +1,5 @@
 {{ config(
-    post_hook = "DROP TABLE public_util.util_runner"
+    post_hook = "DROP TABLE IF EXISTS public_util.util_runner"
 ) }}
 
 WITH aging_ar_bucket_options AS (SELECT * FROM {{ ref("aging_ar_bucket_options") }})

--- a/models/util/util_runner.sql
+++ b/models/util/util_runner.sql
@@ -1,12 +1,15 @@
+{{ config(
+    post_hook = "DROP TABLE public_util.util_runner"
+) }}
 
-with aging_ar_bucket_options as ( select * FROM  {{ ref("aging_ar_bucket_options") }} ),
+WITH aging_ar_bucket_options AS (SELECT * FROM {{ ref("aging_ar_bucket_options") }})
 
-aging_ar_date_types as ( select * FROM  {{ ref("aging_ar_date_types") }} ),
+, aging_ar_date_types AS (SELECT * FROM {{ ref("aging_ar_date_types") }})
 
-aging_ar_group_by_options as ( select * FROM  {{ ref("aging_ar_group_by_options") }} ),
+, aging_ar_group_by_options AS (SELECT * FROM {{ ref("aging_ar_group_by_options") }})
 
-daysheet_date_types as ( select * FROM  {{ ref("daysheet_date_types") }} ),
+, daysheet_date_types AS (SELECT * FROM {{ ref("daysheet_date_types") }})
 
-daysheet_group_by_options as ( select * FROM  {{ ref("daysheet_group_by_options") }} )
+, daysheet_group_by_options AS (SELECT * FROM {{ ref("daysheet_group_by_options") }})
 
 SELECT 1


### PR DESCRIPTION


<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
* "Update: dbt version 0.13.0"
-->

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->
-Added a flag to not bind daysheet summary. 
-Moved all fivetran jobs to deployment.yml. 
-Added posthook to util_runner to drop dummy table. 
-More formatting rules. 

For point 1, this is causing issues with the rebuild on schema change for upstream daysheet tables. They cannot be dropped since the daysheet summary view depends/is binded to those tables. Adding this config is risky because it leaves the summary view hanging, but i think this is ideal for our situation. More info on this topic at link below. 

https://www.getdbt.com/blog/using-redshift-s-late-binding-views-with-dbt


